### PR TITLE
Fixed typo in class name

### DIFF
--- a/notebooks/05-Euclid.ipynb
+++ b/notebooks/05-Euclid.ipynb
@@ -464,7 +464,7 @@
     "    def __str__(self):\n",
     "        return repr(self.value)\n",
     "    \n",
-    "class MyExceptoin(Exception):\n",
+    "class MyException(Exception):\n",
     "    def __init__(self, value):\n",
     "        self.value = value\n",
     "    def __str__(self):\n",


### PR DESCRIPTION
I fixed a simple typo in a class name.
